### PR TITLE
Include common labels in chart template

### DIFF
--- a/function/templates/ScaledObject.yaml
+++ b/function/templates/ScaledObject.yaml
@@ -2,6 +2,7 @@ apiVersion: keda.k8s.io/v1alpha1
 kind: ScaledObject
 metadata:
   name: {{ template "hmcts.releasename.v2" . }}
+  {{- ( include "hmcts.labels.v2" . ) | indent 2 }}
 spec:
   scaleType: {{ .Values.scaleType }}
   pollingInterval: {{ .Values.pollingInterval }}

--- a/function/templates/TriggerAuthentication.yaml
+++ b/function/templates/TriggerAuthentication.yaml
@@ -3,6 +3,7 @@ apiVersion: keda.k8s.io/v1alpha1
 kind: TriggerAuthentication
 metadata:
   name:  {{ tpl .Values.triggerAuthName $ }}
+{{- ( include "hmcts.labels.v2" . ) | indent 2 }}
 spec:
   podIdentity:
     provider: {{ .Values.triggerPodIdentityProvider }} # none | azure | gcp | spiffe | aws-eks | aws-kiam


### PR DESCRIPTION
Fix for following error

```
Error: rendered manifests contain a resource that already exists. Unable to continue with install: TriggerAuthentication "azure-blob-auth" in namespace "rpe" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "rpe-send-letter-service-container-new-staging"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "rpe"
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
