### PR TITLE
DTSPO 23130: Updating repo reference to OCI endpoint of chart-library

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,6 @@
 
 Basic helm chart for running functions using [KEDA.](https://keda.sh/)
 
-## Breaking Changes
-
-**v2.2.0**:
-``` yaml
-scaleType: Job | Object # must be specified due to now supporting ScaledJob & ScaledObject
-```
-
-the following value has adjusted:
-```yaml
-triggerPodIdentityProvider: Azure
-```
-becomes:
-```yaml
-triggerAuth:
-  triggerPodIdentityProvider: Azure
-```
-
 ## Releases
 We use semantic versioning via GitHub releases to handle new releases of this application chart, this is done via automation called Release Drafter. When you merge a PR to master, a new draft release will be created.
 More information is available about the [release process and how to create draft releases for testing purposes in more depth](https://hmcts.github.io/ops-runbooks/Testing-Changes/drafting-a-release.html)
@@ -83,9 +66,7 @@ triggers
     targetQueryValue: "1.1"
 ```
 
-## Pod Identity Auth
-
-Supported for both Blob Storage Trigger & Service Bus Trigger.
+## Using Azure Triggers
 
 Blob Storage Trigger - Supply the `accountName` value of the Storage Account which the Blob Store is in and leave the `connection` value empty.
 
@@ -100,31 +81,4 @@ values:
       enabled: true
       nameOverride: "azure-mi-auth{{ .Values.something-dynamic-even }}"
 ...
-```
-
-## Upgrading from 0.x.x
-Since version `1.0.0`, the chart now supports multiple triggers of different types and as such, the `Values` need to be 
-supplied as a list instead of a single object.
-
-Example of `0.x.x` `Values`
-```helmyaml
-values:
-  function:
-    trigger:
-      type: azure-blob
-      blob:
-        blobContainerName: "new"
-        accountName: "rpesendletterdemo"
-```
-
-Since `1.0.0`
-```helmyaml
-values:
-  function:
-    triggerAuth:
-      enabled: true
-    triggers:
-      - type: azure-blob
-        blobContainerName: "new"
-        accountName: "rpesendletterdemo"
 ```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,32 @@
 
 Basic helm chart for running functions using [KEDA.](https://keda.sh/)
 
+## Breaking Changes
+
+**v2.2.0**:
+``` yaml
+scaleType: Job | Object # must be specified due to now supporting ScaledJob & ScaledObject
+```
+the following value has adjusted:
+```yaml
+triggerPodIdentityProvider: Azure
+```
+becomes:
+```yaml
+triggerAuth:
+  triggerPodIdentityProvider: Azure
+```
+
+**v2.6.0**:
+
+this value has been updated to:
+
+```yaml
+triggerAuth:
+  triggerPodIdentityProvider: azure-workload
+```
+
+
 ## Releases
 We use semantic versioning via GitHub releases to handle new releases of this application chart, this is done via automation called Release Drafter. When you merge a PR to master, a new draft release will be created.
 More information is available about the [release process and how to create draft releases for testing purposes in more depth](https://hmcts.github.io/ops-runbooks/Testing-Changes/drafting-a-release.html)
@@ -81,4 +107,30 @@ values:
       enabled: true
       nameOverride: "azure-mi-auth{{ .Values.something-dynamic-even }}"
 ...
+```
+## Upgrading from 0.x.x
+Since version `1.0.0`, the chart now supports multiple triggers of different types and as such, the `Values` need to be 
+supplied as a list instead of a single object.
+
+Example of `0.x.x` `Values`
+```helmyaml
+values:
+  function:
+    trigger:
+      type: azure-blob
+      blob:
+        blobContainerName: "new"
+        accountName: "rpesendletterdemo"
+```
+
+Since `1.0.0`
+```helmyaml
+values:
+  function:
+    triggerAuth:
+      enabled: true
+    triggers:
+      - type: azure-blob
+        blobContainerName: "new"
+        accountName: "rpesendletterdemo"
 ```

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ triggers
 
 ## Using Azure Triggers
 
+Supported for both Blob Storage Trigger & Service Bus Trigger.
+
 Blob Storage Trigger - Supply the `accountName` value of the Storage Account which the Blob Store is in and leave the `connection` value empty.
 
 Service Bus Trigger - Supply `serviceBusNamespace` value of the Service Bus namespace name, leave connection empty.

--- a/ci-values-blob-release-name.yaml
+++ b/ci-values-blob-release-name.yaml
@@ -3,7 +3,7 @@ scaleType: Job
 triggerAuth:
   enabled: true
   create: true
-  triggerPodIdentityProvider: "azure"
+  triggerPodIdentityProvider: "azure-workload"
 triggers:
   - type: azure-blob
     # Required: blobContainerName and connection

--- a/ci-values-blob.yaml
+++ b/ci-values-blob.yaml
@@ -4,7 +4,7 @@ triggerAuth:
   enabled: true
   create: true
   nameOverride: "azure-mi-auth-{{ lower .Values.scaleType }}"
-  triggerPodIdentityProvider: "azure"
+  triggerPodIdentityProvider: "azure-workload"
 triggers:
   - type: azure-blob
     # Required: blobContainerName and connection

--- a/ci-values-servicebus.yaml
+++ b/ci-values-servicebus.yaml
@@ -4,7 +4,7 @@ scaleType: Job
 triggerAuth:
   create: true
   enabled: true
-  triggerPodIdentityProvider: "azure"
+  triggerPodIdentityProvider: "azure-workload"
 triggers:
 - type: azure-servicebus
   serviceBusName: "test-sbus" # required if triggerAuth.Enabled = true

--- a/function/Chart.yaml
+++ b/function/Chart.yaml
@@ -22,5 +22,5 @@ appVersion: 0.1.0
 
 dependencies: # A list of the chart requirements (optional)
   - name: library
-    version: 2.1.1
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
+    version: 2.2.2
+    repository: oci://hmctspublic.azurecr.io/helm

--- a/function/templates/ScaledJob.yaml
+++ b/function/templates/ScaledJob.yaml
@@ -21,7 +21,7 @@ spec:
     completions: {{ .Values.job.completions }}
     activeDeadlineSeconds: {{ .Values.job.activeDeadlineSeconds }}
     backoffLimit: {{ .Values.job.backoffLimit }}
-{{ include "hmcts.podtemplate.v5.tpl" . | indent 4 }}
+{{ include "hmcts.podtemplate.v6.tpl" . | indent 4 }}
   triggers:
     {{- range .Values.triggers }}
       {{- $data := dict "root" $ "trigger" . }}


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-23130

### Change description

- Updating Chart library reference to point at the new OCI endpoint this also required bumping from v2.1.1 to v2.2.2 as part of the upgrade work for DTSPO-23130.
- All base charts will need an update as part of this work.
- The new release off the back of this PR will also move chart-function to the OCI endpoint.
- Updated triggerPodIdentityProvider to "azure-workload" from "azure"

### Testing

Tested using this [PR](https://github.com/hmcts/cnp-plum-recipes-service/pull/1118) on the cnp-plum-recipe-service repo and pipeline.
Also tested by raising a [PR](https://github.com/hmcts/recipe-receiver/pull/109) in the recipe-receiver repo.
Build successfully went green with the changes in this PR using the [pre-release](https://github.com/hmcts/chart-java/releases/tag/v5.3.0-beta) for chart java V5

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
